### PR TITLE
Apply Changes without Reloading (and other fixes)

### DIFF
--- a/Bind.xaml
+++ b/Bind.xaml
@@ -19,7 +19,7 @@
         </Grid.ColumnDefinitions>
         <Label Grid.Row="0" Grid.Column="0" Content="Bind Name" HorizontalAlignment="Left" VerticalAlignment="Center"/>
         <Label Grid.Row="0" Grid.Column="2" Content="Property Value" HorizontalAlignment="Left" VerticalAlignment="Center"/>
-        <TextBox x:Name="txtBindName" Grid.Row="0" Grid.Column="1" TextWrapping="NoWrap" Text="{Binding ActionName}" Margin="5,2,20,2" VerticalContentAlignment="Center"/>
+        <TextBox x:Name="txtBindName" Grid.Row="0" Grid.Column="1" TextWrapping="NoWrap" Text="{Binding NameTextBoxValue}" BorderBrush="{Binding BorderBrush}" Margin="5,2,20,2" VerticalContentAlignment="Center"/>
         <TextBox x:Name="txtBindValue" Grid.Row="0" Grid.Column="3" TextWrapping="NoWrap" Text="{Binding PropertyValue}" Margin="5,2,6,2" VerticalContentAlignment="Center"/>
         <ui:ControlsEditor Grid.Row="0" Grid.Column="4">
             <ui:ControlsEditor.ActionName>

--- a/CyclerBind.xaml
+++ b/CyclerBind.xaml
@@ -19,7 +19,7 @@
         </Grid.ColumnDefinitions>
         <Label Grid.Row="0" Grid.Column="0" Content="Bind Name" HorizontalAlignment="Left" VerticalAlignment="Center"/>
         <Label Grid.Row="0" Grid.Column="2" Content="Direction" HorizontalAlignment="Left" VerticalAlignment="Center"/>
-        <TextBox x:Name="txtBindName" Grid.Row="0" Grid.Column="1" TextWrapping="NoWrap" Text="{Binding ActionName}" Margin="5,2,20,2" VerticalContentAlignment="Center"/>
+        <TextBox x:Name="txtBindName" Grid.Row="0" Grid.Column="1" TextWrapping="NoWrap" Text="{Binding NameTextBoxValue}" BorderBrush="{Binding BorderBrush}" Margin="5,2,20,2" VerticalContentAlignment="Center"/>
         <ComboBox x:Name="txtBindValue" Grid.Row="0" Grid.Column="3" Text="{Binding Direction}" Margin="5,2,6,2" VerticalContentAlignment="Center" IsReadOnly="True">
             <ComboBoxItem Content="Forward"/>
             <ComboBoxItem Content="Backward"/>

--- a/Property.xaml
+++ b/Property.xaml
@@ -17,7 +17,7 @@
         <styles:SHExpander.HeaderTemplate>
             <DataTemplate>
                 <Grid>
-                    <TextBox x:Name="txtPropertyName" Text="{Binding PropertyName}" BorderBrush="{Binding BorderBrush}" DataContext="{Binding DataContext, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:Property}}}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="5,0,0,0" Width="Auto" MinWidth="100"/>
+                    <TextBox x:Name="txtPropertyName" Text="{Binding NameTextBoxValue}" BorderBrush="{Binding BorderBrush}" DataContext="{Binding DataContext, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:Property}}}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="5,0,0,0" Width="Auto" MinWidth="100"/>
                     <styles:SHButtonSecondary x:Name="btnDeleteProperty" Command="{x:Static local:SettingsControl.DeletePropertyCommand}" CommandParameter="{Binding DataContext, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:Property}}}" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,5,0">Delete</styles:SHButtonSecondary>
                 </Grid>
             </DataTemplate>

--- a/Property.xaml
+++ b/Property.xaml
@@ -24,9 +24,9 @@
         </styles:SHExpander.HeaderTemplate>
         <StackPanel Orientation="Vertical">
             <StackPanel Orientation="Horizontal">
-                <styles:SHButtonSecondary x:Name="btnAddBind" HorizontalAlignment="Left" Click="btnAddBind_Click">New bind</styles:SHButtonSecondary>
-                <styles:SHButtonSecondary x:Name="btnAddCyclerBind" HorizontalAlignment="Left" Click="btnAddCyclerBind_Click">New cycler bind</styles:SHButtonSecondary>
-                <styles:SHButtonSecondary x:Name="btnAddToggleBind" HorizontalAlignment="Left" Click="btnAddToggleBind_Click">New toggle bind</styles:SHButtonSecondary>
+                <styles:SHButtonSecondary x:Name="btnAddBind" HorizontalAlignment="Left" Click="btnAddBind_Click" ToolTip="A normal Bind. You can either assign a Button, or just use a Cycler/Toggle to activate this, or both">New Bind</styles:SHButtonSecondary>
+                <styles:SHButtonSecondary x:Name="btnAddCyclerBind" HorizontalAlignment="Left" Click="btnAddCyclerBind_Click" ToolTip="Cycles either Forwards or Backwards through all normal binds">New Cycler Bind</styles:SHButtonSecondary>
+                <styles:SHButtonSecondary x:Name="btnAddToggleBind" HorizontalAlignment="Left" Click="btnAddToggleBind_Click" ToolTip="Press the assigned Button to activate, a further press will return the value to the previously active Bind">New Toggle Bind</styles:SHButtonSecondary>
             </StackPanel>
             <ItemsControl x:Name="pnlBinds" ItemsSource="{Binding Binds}">
                 <ItemsControl.Resources>

--- a/Property.xaml
+++ b/Property.xaml
@@ -17,7 +17,7 @@
         <styles:SHExpander.HeaderTemplate>
             <DataTemplate>
                 <Grid>
-                    <TextBox x:Name="txtPropertyName" Text="{Binding PropertyName}" DataContext="{Binding DataContext, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:Property}}}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="5,0,0,0" Width="Auto" MinWidth="100"/>
+                    <TextBox x:Name="txtPropertyName" Text="{Binding PropertyName}" BorderBrush="{Binding BorderBrush}" DataContext="{Binding DataContext, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:Property}}}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="5,0,0,0" Width="Auto" MinWidth="100"/>
                     <styles:SHButtonSecondary x:Name="btnDeleteProperty" Command="{x:Static local:SettingsControl.DeletePropertyCommand}" CommandParameter="{Binding DataContext, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:Property}}}" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,5,0">Delete</styles:SHButtonSecondary>
                 </Grid>
             </DataTemplate>

--- a/Property.xaml.cs
+++ b/Property.xaml.cs
@@ -29,17 +29,44 @@ namespace SwitchableProperties
 
         private void btnAddBind_Click(object sender, RoutedEventArgs e)
         {
-            ((IList)pnlBinds.ItemsSource).Add(new SwitchableValueBind());
+            var binds = ((IList)pnlBinds.ItemsSource);
+
+            binds.Add(new SwitchableValueBind() { ActionName =  $"{((SwitchableProperty)this.DataContext).PropertyName}_{binds.Count}"});
         }
 
         private void btnAddCyclerBind_Click(object sender, RoutedEventArgs e)
         {
-            ((IList)pnlBinds.ItemsSource).Add(new SwitchableCyclerBind());
+            var binds = ((IList)pnlBinds.ItemsSource);
+
+            if (binds.Count == 0)
+            {
+                //Generating a template
+                binds.Add(new SwitchableValueBind() { ActionName = $"{((SwitchableProperty)this.DataContext).PropertyName}_{binds.Count}" });
+                binds.Add(new SwitchableValueBind() { ActionName = $"{((SwitchableProperty)this.DataContext).PropertyName}_{binds.Count}" });
+                binds.Add(new SwitchableCyclerBind() { ActionName = "Cycler", Direction = "Forward" });
+            }
+            else
+            {
+                binds.Add(new SwitchableCyclerBind() { ActionName = $"{((SwitchableProperty)this.DataContext).PropertyName}_{binds.Count}_Cycler" });
+            }
         }
 
         private void btnAddToggleBind_Click(object sender, RoutedEventArgs e)
         {
-            ((IList)pnlBinds.ItemsSource).Add(new SwitchableToggleBind());
+            var binds = ((IList)pnlBinds.ItemsSource);
+
+            if (binds.Count == 0)
+            {
+                //Generating a template
+                binds.Add(new SwitchableValueBind() { ActionName = "Default" });
+                binds.Add(new SwitchableToggleBind() { ActionName = "Toggle" });
+
+            }
+            else
+            {
+                binds.Add(new SwitchableToggleBind() { ActionName = $"{((SwitchableProperty)this.DataContext).PropertyName}_{binds.Count}_Toggle" });
+            }
+            
         }
 
         private void DeleteBind_OnExecuted(object sender, ExecutedRoutedEventArgs e)

--- a/Property.xaml.cs
+++ b/Property.xaml.cs
@@ -32,7 +32,9 @@ namespace SwitchableProperties
             var binds = ((IList)pnlBinds.ItemsSource);
             var property = ((SwitchableProperty)this.DataContext);
 
-            binds.Add(new SwitchableValueBind() { ActionName =  $"{((SwitchableProperty)this.DataContext).PropertyName}_{binds.Count}", Plugin = property.Plugin, Property = property });
+            binds.Add(new SwitchableValueBind() { ActionName =  $"{property.PropertyName}_{binds.Count}", Plugin = property.Plugin, Property = property });
+
+            property.Plugin.GenerateBinds();
         }
 
         private void btnAddCyclerBind_Click(object sender, RoutedEventArgs e)
@@ -43,14 +45,16 @@ namespace SwitchableProperties
             if (binds.Count == 0)
             {
                 //Generating a template
-                binds.Add(new SwitchableValueBind() { ActionName = $"{((SwitchableProperty)this.DataContext).PropertyName}_{binds.Count}", Plugin = property.Plugin, Property = property });
-                binds.Add(new SwitchableValueBind() { ActionName = $"{((SwitchableProperty)this.DataContext).PropertyName}_{binds.Count}", Plugin = property.Plugin, Property = property });
+                binds.Add(new SwitchableValueBind() { ActionName = $"{property.PropertyName}_{binds.Count}", Plugin = property.Plugin, Property = property });
+                binds.Add(new SwitchableValueBind() { ActionName = $"{property.PropertyName}_{binds.Count}", Plugin = property.Plugin, Property = property });
                 binds.Add(new SwitchableCyclerBind() { ActionName = "Cycler", Direction = "Forward", Plugin = property.Plugin, Property = property });
             }
             else
             {
                 binds.Add(new SwitchableCyclerBind() { ActionName = $"{((SwitchableProperty)this.DataContext).PropertyName}_{binds.Count}_Cycler", Plugin = property.Plugin, Property = property });
             }
+
+            property.Plugin.GenerateBinds();
         }
 
         private void btnAddToggleBind_Click(object sender, RoutedEventArgs e)
@@ -69,7 +73,8 @@ namespace SwitchableProperties
             {
                 binds.Add(new SwitchableToggleBind() { ActionName = $"{property.PropertyName}_{binds.Count}_Toggle", Plugin = property.Plugin, Property = property });
             }
-            
+
+            property.Plugin.GenerateBinds();
         }
 
         private void DeleteBind_OnExecuted(object sender, ExecutedRoutedEventArgs e)

--- a/Property.xaml.cs
+++ b/Property.xaml.cs
@@ -79,7 +79,14 @@ namespace SwitchableProperties
 
         private void DeleteBind_OnExecuted(object sender, ExecutedRoutedEventArgs e)
         {
-            ((SwitchableProperty)this.DataContext).Binds.Remove(e.Parameter as SwitchableBind);
+            var property = ((SwitchableProperty)this.DataContext);
+            var bind = e.Parameter as SwitchableBind;
+
+            property.Binds.Remove(bind);
+
+            property.Plugin.DeleteInputMapTargets($"{property.PropertyName}_{bind.ActionName}");
+            
+            property.Plugin.GenerateBinds();
         }
     }
 }

--- a/Property.xaml.cs
+++ b/Property.xaml.cs
@@ -30,41 +30,44 @@ namespace SwitchableProperties
         private void btnAddBind_Click(object sender, RoutedEventArgs e)
         {
             var binds = ((IList)pnlBinds.ItemsSource);
+            var property = ((SwitchableProperty)this.DataContext);
 
-            binds.Add(new SwitchableValueBind() { ActionName =  $"{((SwitchableProperty)this.DataContext).PropertyName}_{binds.Count}"});
+            binds.Add(new SwitchableValueBind() { ActionName =  $"{((SwitchableProperty)this.DataContext).PropertyName}_{binds.Count}", Plugin = property.Plugin, Property = property });
         }
 
         private void btnAddCyclerBind_Click(object sender, RoutedEventArgs e)
         {
             var binds = ((IList)pnlBinds.ItemsSource);
+            var property = ((SwitchableProperty)this.DataContext);
 
             if (binds.Count == 0)
             {
                 //Generating a template
-                binds.Add(new SwitchableValueBind() { ActionName = $"{((SwitchableProperty)this.DataContext).PropertyName}_{binds.Count}" });
-                binds.Add(new SwitchableValueBind() { ActionName = $"{((SwitchableProperty)this.DataContext).PropertyName}_{binds.Count}" });
-                binds.Add(new SwitchableCyclerBind() { ActionName = "Cycler", Direction = "Forward" });
+                binds.Add(new SwitchableValueBind() { ActionName = $"{((SwitchableProperty)this.DataContext).PropertyName}_{binds.Count}", Plugin = property.Plugin, Property = property });
+                binds.Add(new SwitchableValueBind() { ActionName = $"{((SwitchableProperty)this.DataContext).PropertyName}_{binds.Count}", Plugin = property.Plugin, Property = property });
+                binds.Add(new SwitchableCyclerBind() { ActionName = "Cycler", Direction = "Forward", Plugin = property.Plugin, Property = property });
             }
             else
             {
-                binds.Add(new SwitchableCyclerBind() { ActionName = $"{((SwitchableProperty)this.DataContext).PropertyName}_{binds.Count}_Cycler" });
+                binds.Add(new SwitchableCyclerBind() { ActionName = $"{((SwitchableProperty)this.DataContext).PropertyName}_{binds.Count}_Cycler", Plugin = property.Plugin, Property = property });
             }
         }
 
         private void btnAddToggleBind_Click(object sender, RoutedEventArgs e)
         {
             var binds = ((IList)pnlBinds.ItemsSource);
+            var property = ((SwitchableProperty)this.DataContext);
 
             if (binds.Count == 0)
             {
                 //Generating a template
-                binds.Add(new SwitchableValueBind() { ActionName = "Default" });
-                binds.Add(new SwitchableToggleBind() { ActionName = "Toggle" });
+                binds.Add(new SwitchableValueBind() { ActionName = "Default", Plugin = property.Plugin, Property = property });
+                binds.Add(new SwitchableToggleBind() { ActionName = "Toggle", Plugin = property.Plugin, Property = property });
 
             }
             else
             {
-                binds.Add(new SwitchableToggleBind() { ActionName = $"{((SwitchableProperty)this.DataContext).PropertyName}_{binds.Count}_Toggle" });
+                binds.Add(new SwitchableToggleBind() { ActionName = $"{property.PropertyName}_{binds.Count}_Toggle", Plugin = property.Plugin, Property = property });
             }
             
         }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ For example, if you wanted to create a tabular menu system in a dash/overlay, wh
 - Create a property in the plugin
 - Create binds for each menu tab specifying a memorable bind name, and a value
 - Connect these binds to an input (keyboard press, button press etc.)
-- Restart SimHub, or change game (re-initialise the plugin)
 - Enter Dashstudio with your chosen dash
 - On each widget you wish to connect to the property, enable the "Fx" of the Visible property
 - In the "Fx" of the Visible property, a simple check for the property matching a desired bind name is written, for example, "SwitchableProperties.Page1 == 'tyres'". In this case, the property name is "Page 1", and the property value to match against is "tyres"

--- a/SettingsControl.xaml
+++ b/SettingsControl.xaml
@@ -20,6 +20,7 @@
                 </Grid.RowDefinitions>
                 <styles:SHButtonPrimary Grid.Row="0" x:Name="btnAddProperty" HorizontalAlignment="Left" Click="btnAddProperty_Click">New property</styles:SHButtonPrimary>
                 <StackPanel Orientation="Horizontal" Grid.Row="0" HorizontalAlignment="Right">
+                    <styles:SHButtonPrimary x:Name="btnApply" HorizontalAlignment="Left" Click="btnApply_Click">Apply</styles:SHButtonPrimary>
                     <styles:SHButtonPrimary x:Name="btnImport" HorizontalAlignment="Left" Click="btnImport_Click">Import</styles:SHButtonPrimary>
                     <styles:SHButtonPrimary x:Name="btnExport" HorizontalAlignment="Left" Click="btnExport_Click">Export</styles:SHButtonPrimary>
                 </StackPanel>

--- a/SettingsControl.xaml
+++ b/SettingsControl.xaml
@@ -18,10 +18,10 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition/>
                 </Grid.RowDefinitions>
-                <styles:SHButtonPrimary Grid.Row="0" x:Name="btnAddProperty" HorizontalAlignment="Left" Click="btnAddProperty_Click">New property</styles:SHButtonPrimary>
+                <styles:SHButtonPrimary Grid.Row="0" x:Name="btnAddProperty" HorizontalAlignment="Left" Click="btnAddProperty_Click" ToolTip="Create A New Property">New Property</styles:SHButtonPrimary>
                 <StackPanel Orientation="Horizontal" Grid.Row="0" HorizontalAlignment="Right">
-                    <styles:SHButtonPrimary x:Name="btnImport" HorizontalAlignment="Left" Click="btnImport_Click">Import</styles:SHButtonPrimary>
-                    <styles:SHButtonPrimary x:Name="btnExport" HorizontalAlignment="Left" Click="btnExport_Click">Export</styles:SHButtonPrimary>
+                    <styles:SHButtonPrimary x:Name="btnImport" HorizontalAlignment="Left" Click="btnImport_Click" ToolTip="Import and Override all current Properties and Binds">Import</styles:SHButtonPrimary>
+                    <styles:SHButtonPrimary x:Name="btnExport" HorizontalAlignment="Left" Click="btnExport_Click" ToolTip="Export all current Properties and Binds (excluding the keybinds)">Export</styles:SHButtonPrimary>
                 </StackPanel>
                 <ScrollViewer Grid.Row="1" CanContentScroll="True" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
                     <ItemsControl x:Name="pnlProperties">

--- a/SettingsControl.xaml
+++ b/SettingsControl.xaml
@@ -20,7 +20,6 @@
                 </Grid.RowDefinitions>
                 <styles:SHButtonPrimary Grid.Row="0" x:Name="btnAddProperty" HorizontalAlignment="Left" Click="btnAddProperty_Click">New property</styles:SHButtonPrimary>
                 <StackPanel Orientation="Horizontal" Grid.Row="0" HorizontalAlignment="Right">
-                    <styles:SHButtonPrimary x:Name="btnApply" HorizontalAlignment="Left" Click="btnApply_Click">Apply</styles:SHButtonPrimary>
                     <styles:SHButtonPrimary x:Name="btnImport" HorizontalAlignment="Left" Click="btnImport_Click">Import</styles:SHButtonPrimary>
                     <styles:SHButtonPrimary x:Name="btnExport" HorizontalAlignment="Left" Click="btnExport_Click">Export</styles:SHButtonPrimary>
                 </StackPanel>

--- a/SettingsControl.xaml.cs
+++ b/SettingsControl.xaml.cs
@@ -45,7 +45,15 @@ namespace SwitchableProperties
 
         private void DeleteProperty_OnExecuted(object sender, ExecutedRoutedEventArgs e)
         {
-            Plugin.Settings.Properties.Remove(e.Parameter as SwitchableProperty);
+            var prop = e.Parameter as SwitchableProperty;
+
+            Plugin.Settings.Properties.Remove(prop);
+
+            foreach (var item in prop.Binds)
+            {
+                Plugin.DeleteInputMapTargets($"{prop.PropertyName}_{item.ActionName}");
+            }
+
             Plugin.GenerateBinds();
         }
 
@@ -74,13 +82,6 @@ namespace SwitchableProperties
                     foreach (var setting in importedSettings.Properties)
                     {
                         Plugin.Settings.Properties.Add(setting);
-                        setting.Plugin = this.Plugin;
-
-                        foreach (var binds in setting.Binds)
-                        {
-                            binds.Plugin = this.Plugin;
-                            binds.Property = setting;
-                        }
                     }
                         
                 }
@@ -95,13 +96,6 @@ namespace SwitchableProperties
                             PropertyName = setting.PropertyName,
                             Binds = new ObservableCollection<SwitchableBind>(setting.Binds)
                         };
-
-                        newSetting.Plugin = this.Plugin;
-                        foreach (var binds in newSetting.Binds)
-                        {
-                            binds.Plugin = this.Plugin;
-                            binds.Property = newSetting;
-                        }
 
                         Plugin.Settings.Properties.Add(newSetting);
                     }

--- a/SettingsControl.xaml.cs
+++ b/SettingsControl.xaml.cs
@@ -107,6 +107,14 @@ namespace SwitchableProperties
 
         private void btnApply_Click(object sender, System.Windows.RoutedEventArgs e)
         {
+            if (Plugin.CheckForCollisions(false))
+            {
+                //Collisions, so we don't apply the update
+                System.Windows.MessageBox.Show("There are properties with the same name, please rename one!","Name Collision", System.Windows.MessageBoxButton.OK, System.Windows.MessageBoxImage.Warning);
+                return;
+            }
+                
+
             Plugin.PluginManager.ClearActions(Plugin.GetType());
             Plugin.PluginManager.ClearProperties(Plugin.GetType());
 

--- a/SettingsControl.xaml.cs
+++ b/SettingsControl.xaml.cs
@@ -126,7 +126,8 @@ namespace SwitchableProperties
                 File.WriteAllText(sfd.FileName,
                     JsonConvert.SerializeObject(Plugin.Settings, new JsonSerializerSettings
                     {
-                        TypeNameHandling = TypeNameHandling.Auto
+                        TypeNameHandling = TypeNameHandling.Auto,
+                        Formatting = Formatting.Indented
                     }));
             }
         }

--- a/SettingsControl.xaml.cs
+++ b/SettingsControl.xaml.cs
@@ -35,14 +35,18 @@ namespace SwitchableProperties
         {
             Plugin.Settings.Properties.Add(new SwitchableProperty
             {
+                PropertyName = "",
                 Binds = new ObservableCollection<SwitchableBind>(),
                 Plugin = this.Plugin
             });
+
+            Plugin.GenerateBinds();
         }
 
         private void DeleteProperty_OnExecuted(object sender, ExecutedRoutedEventArgs e)
         {
             Plugin.Settings.Properties.Remove(e.Parameter as SwitchableProperty);
+            Plugin.GenerateBinds();
         }
 
         private void btnImport_Click(object sender, System.Windows.RoutedEventArgs e)
@@ -102,6 +106,8 @@ namespace SwitchableProperties
                         Plugin.Settings.Properties.Add(newSetting);
                     }
                 }
+
+                Plugin.GenerateBinds();
             }
         }
 

--- a/SettingsControl.xaml.cs
+++ b/SettingsControl.xaml.cs
@@ -59,6 +59,12 @@ namespace SwitchableProperties
 
         private void btnImport_Click(object sender, System.Windows.RoutedEventArgs e)
         {
+            if (Plugin.Settings.Properties.Count > 0)
+            {
+                if (System.Windows.MessageBox.Show("Import DELETES all your existing Properties and Binds, to replace them with the once Imported.\n\nDo you want to continue?", "Import Overrride Warning!", System.Windows.MessageBoxButton.OKCancel, System.Windows.MessageBoxImage.Warning) == System.Windows.MessageBoxResult.Cancel)
+                    return;
+            }
+
             OpenFileDialog ofd = new OpenFileDialog
             {
                 Title = "Browse for settings",

--- a/SettingsControl.xaml.cs
+++ b/SettingsControl.xaml.cs
@@ -105,21 +105,5 @@ namespace SwitchableProperties
                     }));
             }
         }
-
-        private void btnApply_Click(object sender, System.Windows.RoutedEventArgs e)
-        {
-            if (Plugin.CheckForCollisions(false))
-            {
-                //Collisions, so we don't apply the update
-                System.Windows.MessageBox.Show("There are properties with the same name, please rename one!","Name Collision", System.Windows.MessageBoxButton.OK, System.Windows.MessageBoxImage.Warning);
-                return;
-            }
-                
-
-            Plugin.PluginManager.ClearActions(Plugin.GetType());
-            Plugin.PluginManager.ClearProperties(Plugin.GetType());
-
-            Plugin.GenerateBinds();
-        }
     }
 }

--- a/SettingsControl.xaml.cs
+++ b/SettingsControl.xaml.cs
@@ -68,7 +68,17 @@ namespace SwitchableProperties
                         });
                     Plugin.Settings.Properties.Clear();
                     foreach (var setting in importedSettings.Properties)
+                    {
                         Plugin.Settings.Properties.Add(setting);
+                        setting.Plugin = this.Plugin;
+
+                        foreach (var binds in setting.Binds)
+                        {
+                            binds.Plugin = this.Plugin;
+                            binds.Property = setting;
+                        }
+                    }
+                        
                 }
                 catch (JsonSerializationException)
                 {
@@ -76,11 +86,20 @@ namespace SwitchableProperties
                     Plugin.Settings.Properties.Clear();
                     foreach (var setting in importedSettings.Properties)
                     {
-                        Plugin.Settings.Properties.Add(new SwitchableProperty
+                        var newSetting = new SwitchableProperty
                         {
                             PropertyName = setting.PropertyName,
                             Binds = new ObservableCollection<SwitchableBind>(setting.Binds)
-                        });
+                        };
+
+                        newSetting.Plugin = this.Plugin;
+                        foreach (var binds in newSetting.Binds)
+                        {
+                            binds.Plugin = this.Plugin;
+                            binds.Property = newSetting;
+                        }
+
+                        Plugin.Settings.Properties.Add(newSetting);
                     }
                 }
             }

--- a/SettingsControl.xaml.cs
+++ b/SettingsControl.xaml.cs
@@ -104,5 +104,13 @@ namespace SwitchableProperties
                     }));
             }
         }
+
+        private void btnApply_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            Plugin.PluginManager.ClearActions(Plugin.GetType());
+            Plugin.PluginManager.ClearProperties(Plugin.GetType());
+
+            Plugin.GenerateBinds();
+        }
     }
 }

--- a/SettingsControl.xaml.cs
+++ b/SettingsControl.xaml.cs
@@ -35,7 +35,8 @@ namespace SwitchableProperties
         {
             Plugin.Settings.Properties.Add(new SwitchableProperty
             {
-                Binds = new ObservableCollection<SwitchableBind>()
+                Binds = new ObservableCollection<SwitchableBind>(),
+                Plugin = this.Plugin
             });
         }
 

--- a/SwitchableProperties.csproj
+++ b/SwitchableProperties.csproj
@@ -58,6 +58,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />

--- a/SwitchablePropertiesPlugin.cs
+++ b/SwitchablePropertiesPlugin.cs
@@ -181,6 +181,22 @@ namespace SwitchableProperties
                 item.Target = $"SwitchablePropertiesPlugin.{newName}";
             }
         }
+
+        internal void DeleteInputMapTargets(string oldName)
+        {
+            var test = new SimHub.Plugins.UI.ControlsEditor() { Visibility = System.Windows.Visibility.Collapsed, ActionName = $"SwitchablePropertiesPlugin.{oldName}" };
+
+            var inputList = test.Model.Triggers;
+
+            foreach (var item in inputList)
+            {
+                //And this is kind of even more stupid
+                //Setting the Trigger and Target empty allows them to be bound again without promting the user
+                //And SimHub will clean up the empty bind on the next reload
+                item.Target = "";
+                item.Trigger = "";
+            }
+        }
     }
 
     internal class SwitchablePropertyContainer

--- a/SwitchablePropertiesPlugin.cs
+++ b/SwitchablePropertiesPlugin.cs
@@ -87,6 +87,11 @@ namespace SwitchableProperties
             if (Settings.Properties == null)
                 Settings.Properties = new ObservableCollection<SwitchableProperty>();
 
+            GenerateBinds();
+        }
+
+        internal void GenerateBinds()
+        {
             //Initialise properties to their default value (first bind value)
             _switchableProperties = new List<SwitchablePropertyContainer>();
 
@@ -112,7 +117,7 @@ namespace SwitchableProperties
                 this.AttachDelegate($"{property.Property.PropertyName}_ActiveBind", () => property.BindName);
 
 
-                    // Declare an event
+                // Declare an event
                 this.AddEvent($"{property.Property.PropertyName}Update");
 
                 if (property.Property.Binds == null)

--- a/SwitchablePropertiesPlugin.cs
+++ b/SwitchablePropertiesPlugin.cs
@@ -123,7 +123,6 @@ namespace SwitchableProperties
                 this.AttachDelegate($"{property.Property.PropertyName}", () => property.PropertyValue);
                 this.AttachDelegate($"{property.Property.PropertyName}_ActiveBind", () => property.BindName);
 
-
                 // Declare an event
                 this.AddEvent($"{property.Property.PropertyName}Update");
 
@@ -171,10 +170,9 @@ namespace SwitchableProperties
 
         internal void RenameInputMapTargets(string oldName, string newName)
         {
-            //Yes, this is stupid, but it works to gain access to the input maps
-            var test = new SimHub.Plugins.UI.ControlsEditor() { Visibility = System.Windows.Visibility.Collapsed, ActionName = $"SwitchablePropertiesPlugin.{oldName}" };
+            var controlEditor = new SimHub.Plugins.UI.ControlsEditor() { Visibility = System.Windows.Visibility.Collapsed, ActionName = $"SwitchablePropertiesPlugin.{oldName}" };
 
-            var inputList = test.Model.Triggers;
+            var inputList = controlEditor.Model.Triggers;
 
             foreach (var item in inputList)
             {
@@ -190,9 +188,8 @@ namespace SwitchableProperties
 
             foreach (var item in inputList)
             {
-                //And this is kind of even more stupid
-                //Setting the Trigger and Target empty allows them to be bound again without promting the user
-                //And SimHub will clean up the empty bind on the next reload
+                /*Setting the Trigger and Target empty allows them to be bound again without prompting the user
+                And SimHub will clean up the empty bind on the next reload*/
                 item.Target = "";
                 item.Trigger = "";
             }
@@ -297,13 +294,9 @@ namespace SwitchableProperties
 
                     if (PropertyName != value)
                     {
-                        foreach (var item in Plugin.Settings.Properties)
+                        if (Plugin.Settings.Properties.Any(item => item.PropertyName.ToLower().Equals(value.ToLower())))
                         {
-                            if (item.PropertyName.ToLower().Equals(value.ToLower()))
-                            {
-                                collides = true;
-                                break;
-                            }
+                            collides = true;
                         }
                     }
 
@@ -322,7 +315,6 @@ namespace SwitchableProperties
                                 Plugin.RenameInputMapTargets($"{PropertyName}_{item.ActionName}", $"{value}_{item.ActionName}");
                             }
                         }
-
 
                         PropertyName = value;
 

--- a/ToggleBind.xaml
+++ b/ToggleBind.xaml
@@ -19,7 +19,7 @@
         </Grid.ColumnDefinitions>
         <Label Grid.Row="0" Grid.Column="0" Content="Bind Name" HorizontalAlignment="Left" VerticalAlignment="Center"/>
         <Label Grid.Row="0" Grid.Column="2" Content="Toggle Value" HorizontalAlignment="Left" VerticalAlignment="Center"/>
-        <TextBox x:Name="txtBindName" Grid.Row="0" Grid.Column="1" TextWrapping="NoWrap" Text="{Binding ActionName}" Margin="5,2,20,2" VerticalContentAlignment="Center"/>
+        <TextBox x:Name="txtBindName" Grid.Row="0" Grid.Column="1" TextWrapping="NoWrap" Text="{Binding NameTextBoxValue}" BorderBrush="{Binding BorderBrush}" Margin="5,2,20,2" VerticalContentAlignment="Center"/>
         <TextBox x:Name="txtBindValue" Grid.Row="0" Grid.Column="3" TextWrapping="NoWrap" Text="{Binding PropertyValue}" Margin="5,2,6,2" VerticalContentAlignment="Center"/>
         <ui:ControlsEditor Grid.Row="0" Grid.Column="4">
             <ui:ControlsEditor.ActionName>


### PR DESCRIPTION
Saw the plugin pop up and thought it was interesting, saw then that I had to reload (when I know from my own plugins that this is not necessary), so thought I could solve this and a few quirks I found.

Changelog:
- Automatically applies changes
- Fixed being able to name two Properties (and the Binds within) the same (and cause them not to work correctly)
  - Highlighting for when names collide
- Renaming Properties and Binds no longer unbinds InputMaps
- Deleting Properties and Binds removes InputMaps
- When adding a Cycler or Toggle to a Property without any maps will generate a template
   - Cycler spawns with two normal binds and a Cycler in Forward mode
   - Toggle spawns with a normal bind named Default and a Toggle named Toggle
   - If binds already exist it just adds a Cycler/Toggle
   - Binds will also generate with a default name (PropertyName_"number")
- Added Tooltips
- Export now exports a Indented Json for better readability
- Added Warning to Import that it deletes existing Properties